### PR TITLE
fix(steam): filter out duplicate games by app_id

### DIFF
--- a/src-tauri/src/steam.rs
+++ b/src-tauri/src/steam.rs
@@ -131,10 +131,13 @@ pub fn discover_games_at(steam_root: &Path) -> Result<Vec<SteamGame>, SteamError
         return Err(SteamError::NotFound);
     }
     let library_paths = find_library_paths(steam_root)?;
-    let games = library_paths
+    let mut seen = std::collections::HashSet::new();
+    let games: Vec<SteamGame> = library_paths
         .iter()
         .flat_map(|dir| read_games_from_library(dir))
+        .filter(|g| seen.insert(g.app_id))
         .collect();
+
     Ok(games)
 }
 


### PR DESCRIPTION
Steam keeps two separated folders for legacy compatibility.

The issue was that it was retrieving games from both `~/.local/share/Steam` and `~/.steam`.

`~/.local/share/Steam` is used to follow modern XDG directories standards.

`~/.steam` is for legacy compatilibility with older games that still use the original steam path.

The fix was to filter out duplicated entries when searching for games, as both directories are "linked" and would show the same game twice.

<img width="3840" height="2160" alt="Screenshot from 2026-02-21 23-56-46" src="https://github.com/user-attachments/assets/9598f27a-6d01-4bac-9c2c-1bd42bb6c8cd" />

Closes #2