### PR TITLE
small ui changes

### DIFF
--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -371,13 +371,13 @@ onUnmounted(() => {
               <!-- Badges -->
               <span
                 v-if="entry.is_app_bundle"
-                class="shrink-0 text-[10px] px-1.5 py-0.5 rounded-sm bg-zinc-800 text-zinc-500"
-                :class="i === focusedIdx ? 'bg-zinc-700 text-zinc-300' : ''"
+                class="shrink-0 text-[10px] px-1.5 py-0.5 rounded-sm bg-sky-900/60 text-sky-400"
+                :class="i === focusedIdx ? 'bg-sky-800/70 text-sky-300' : ''"
               >.app</span>
               <span
                 v-else-if="entry.is_executable"
-                class="shrink-0 text-[10px] px-1.5 py-0.5 rounded-sm bg-zinc-800 text-zinc-500"
-                :class="i === focusedIdx ? 'bg-zinc-700 text-zinc-300' : ''"
+                class="shrink-0 text-[10px] px-1.5 py-0.5 rounded-sm bg-emerald-900/60 text-emerald-400"
+                :class="i === focusedIdx ? 'bg-emerald-800/70 text-emerald-300' : ''"
               >exec</span>
             </div>
           </div>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -74,8 +74,8 @@ const emit = defineEmits<{
       <select
         :value="sortOption"
         @change="emit('update:sortOption', ($event.target as HTMLSelectElement).value as SortOption)"
-        class="w-full px-2 py-1.5 text-sm bg-zinc-900 text-white rounded-md border border-zinc-800
-               focus:outline-none focus:border-zinc-600 cursor-pointer transition-colors"
+        class="w-full px-2 py-1.5 text-sm bg-zinc-900 text-zinc-300 rounded-md border border-zinc-700
+               focus:outline-none hover:bg-zinc-800 hover:text-white cursor-pointer transition-colors"
       >
         <option value="alpha">A – Z</option>
         <option value="recentlyAdded">Recently Added</option>


### PR DESCRIPTION
## Summary
- Sort by select now matches the button style (border-zinc-700, text-zinc-300, hover states)
- File explorer badges are now colorful: `.app` in sky blue, `exec` in emerald green