### PR TITLE
fix: custom cover images not displaying

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["**/*"]
+      }
     }
   },
   "bundle": {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,3 +1,5 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+
 export type Platform = "steam" | "custom";
 
 export interface SteamGame {
@@ -48,8 +50,13 @@ export function fromCustomGame(g: CustomGame): Game {
     key: `custom-${g.id}`,
     title: g.title,
     platform: "custom",
-    coverImage: g.cover_image,
+    coverImage: resolveCustomCover(g.cover_image),
     executable: g.executable,
     tags: g.tags,
   };
+}
+
+function resolveCustomCover(path: string | null): string | null {
+  if (!path) return null;
+  return convertFileSrc(path);
 }


### PR DESCRIPTION
## Summary
- Enable `assetProtocol` in `tauri.conf.json` so the WebView can serve local files via `asset://`
- Import `convertFileSrc` from `@tauri-apps/api/core` in `src/types/game.ts`
- Apply it in a `resolveCustomCover` helper called from `fromCustomGame()` to convert bare filesystem paths into loadable `asset://localhost/...` URLs

Steam cover URLs (HTTPS) are unaffected.

Closes #4

## Test plan
- [x] Run `yarn tauri dev`
- [x] Add a custom game with a local image as cover
- [x] Confirm cover renders in the library grid (`GameCard.vue`)
- [x] Open launch dialog — confirm cover renders in `LaunchConfirmDialog.vue`
- [x] Confirm Steam game covers (HTTPS) still render correctly