### PR TITLE
feat: Epic Games library integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ A Tauri desktop application that acts as a personal game library manager, allowi
 - Sorting options: alphabetical, recently added, playtime
 
 ## Tech Stack
-- **Frontend:** Tauri + React (TypeScript)
+- **Frontend:** Tauri + Vue 3 (TypeScript)
 - **Backend (Rust):** Tauri commands for file system access, Steam VDF parsing, and process spawning
 - **Styling:** Tailwind CSS for the library UI
 
@@ -33,22 +33,32 @@ A Tauri desktop application that acts as a personal game library manager, allowi
 - Use Java records for DTOs (when applicable to any JVM tooling in the project)
 - Keep methods that handle data inside the relevant class (high cohesion)
 
-## Project Structure (planned)
+## Project Structure (actual)
 ```
 game-library/
-├── src/                  # React frontend
+├── src/                  # Vue 3 frontend
 │   ├── components/
-│   │   ├── GameCard.tsx
-│   │   ├── GameGrid.tsx
-│   │   └── Sidebar.tsx
-│   └── pages/
-│       └── Library.tsx
+│   │   ├── GameCard.vue
+│   │   ├── GameGrid.vue
+│   │   ├── Sidebar.vue
+│   │   ├── AddGameModal.vue
+│   │   ├── LaunchConfirmDialog.vue
+│   │   ├── FileExplorer.vue
+│   │   └── VirtualKeyboard.vue
+│   ├── composables/
+│   │   └── useGamepad.ts
+│   ├── types/
+│   │   └── game.ts
+│   ├── App.vue
+│   └── main.ts
 ├── src-tauri/            # Rust backend
 │   ├── src/
 │   │   ├── main.rs
+│   │   ├── lib.rs        # Tauri commands and app state
 │   │   ├── steam.rs      # Steam VDF parsing & game discovery
-│   │   ├── library.rs    # Non-steam game management
-│   │   └── launcher.rs   # Game process spawning
+│   │   ├── library.rs    # Custom game management (JSON persistence)
+│   │   ├── launcher.rs   # Game process spawning and URI dispatch
+│   │   └── fs_explorer.rs # File system utilities
 │   └── tauri.conf.json
 └── CLAUDE.md
 ```
@@ -66,3 +76,10 @@ game-library/
 - **Gamepad (Controller):** D-pad / left stick to move focus between game cards, A/Cross to launch, B/Circle to go back, trigger or bumper shortcuts for filtering
 - Controller input handled via the frontend (e.g., `gamepad` browser API available in Tauri's WebView)
 - Visual focus indicator must be clearly visible for controller navigation (big cursor / highlight on focused card)
+
+## Active Technologies
+- Rust (backend), TypeScript 5 + Vue 3 (frontend) + `serde_json` (already in Cargo.toml), `thiserror` (already used), (001-epic-games-integration)
+- None — Epic manifests are read-only; no new persistence layer needed (001-epic-games-integration)
+
+## Recent Changes
+- 001-epic-games-integration: Added Rust (backend), TypeScript 5 + Vue 3 (frontend) + `serde_json` (already in Cargo.toml), `thiserror` (already used),

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1633,6 +1633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,6 +3858,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/epic.rs
+++ b/src-tauri/src/epic.rs
@@ -1,0 +1,316 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EpicGame {
+    /// Stable unique identifier from the manifest `AppName` field.
+    pub app_name: String,
+    /// Human-readable title from the manifest `DisplayName` field.
+    pub display_name: String,
+    /// Absolute path to the game's installation directory.
+    pub install_location: PathBuf,
+    /// Epic catalog namespace (used in the launch URI).
+    pub catalog_namespace: String,
+    /// Epic catalog item ID (used in the launch URI).
+    pub catalog_item_id: String,
+    /// Absolute path to a local cover image, or `None` when not found.
+    pub cover_image: Option<PathBuf>,
+}
+
+impl EpicGame {
+    /// Constructs the Epic Games Launcher URI for this game.
+    pub fn launch_uri(&self) -> String {
+        format!(
+            "com.epicgames.launcher://apps/{}%3A{}%3A{}?action=launch&silent=true",
+            self.catalog_namespace, self.catalog_item_id, self.app_name
+        )
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum EpicError {
+    #[error("Epic Games Launcher not found")]
+    NotFound,
+    #[error("Failed to read Epic manifest directory: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Manifest schema (only fields we care about)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct Manifest {
+    app_name: Option<String>,
+    display_name: Option<String>,
+    install_location: Option<String>,
+    catalog_namespace: Option<String>,
+    catalog_item_id: Option<String>,
+    #[serde(rename = "bIsApplication", default)]
+    b_is_application: bool,
+    #[serde(rename = "bIsExecutable", default)]
+    b_is_executable: bool,
+    #[serde(rename = "bIsIncompleteInstall", default)]
+    b_is_incomplete_install: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Returns all installed Epic games, or `Ok(vec![])` if the launcher is absent.
+pub fn discover_games() -> Result<Vec<EpicGame>, EpicError> {
+    match manifest_dir() {
+        Some(dir) => discover_games_from(&dir),
+        None => Ok(vec![]),
+    }
+}
+
+/// Discovers Epic games from a specific manifest directory (used in tests).
+pub fn discover_games_from(manifest_dir: &Path) -> Result<Vec<EpicGame>, EpicError> {
+    if !manifest_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let entries = std::fs::read_dir(manifest_dir)?;
+    let mut games = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("item") {
+            if let Some(game) = parse_manifest(&path) {
+                games.push(game);
+            }
+        }
+    }
+
+    Ok(games)
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the platform-appropriate Epic manifest directory path.
+fn manifest_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var("HOME").ok()?;
+        Some(
+            PathBuf::from(home)
+                .join("Library/Application Support/Epic/EpicGamesLauncher/Data/Manifests"),
+        )
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Some(PathBuf::from(
+            r"C:\ProgramData\Epic\EpicGamesLauncher\Data\Manifests",
+        ))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+/// Parses a single `.item` manifest file; returns `None` if it should be skipped.
+fn parse_manifest(path: &Path) -> Option<EpicGame> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let m: Manifest = serde_json::from_str(&contents).ok()?;
+
+    // Apply Epic filter rules
+    if !m.b_is_application || !m.b_is_executable || m.b_is_incomplete_install {
+        return None;
+    }
+
+    let app_name = m.app_name.filter(|s| !s.is_empty())?;
+    let display_name = m.display_name.filter(|s| !s.is_empty())?;
+    let install_location = m.install_location.filter(|s| !s.is_empty())?;
+    let catalog_namespace = m.catalog_namespace.unwrap_or_default();
+    let catalog_item_id = m.catalog_item_id.unwrap_or_default();
+
+    let install_path = PathBuf::from(&install_location);
+    let cover_image = find_cover_image(&install_path);
+
+    Some(EpicGame {
+        app_name,
+        display_name,
+        install_location: install_path,
+        catalog_namespace,
+        catalog_item_id,
+        cover_image,
+    })
+}
+
+/// Scans the game's install directory (depth 1) for the first PNG or JPEG file.
+fn find_cover_image(install_dir: &Path) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(install_dir).ok()?;
+    entries.flatten().find_map(|e| {
+        let p = e.path();
+        if p.is_file() {
+            match p.extension().and_then(|ex| ex.to_str()) {
+                Some("png") | Some("jpg") | Some("jpeg") => Some(p),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    })
+}
+
+// ============================================================
+// Tests
+// ============================================================
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // Writes a minimal valid .item manifest to `dir/name.item`.
+    fn write_manifest(dir: &Path, name: &str, extra: &str) {
+        let content = format!(
+            r#"{{
+  "AppName": "{name}",
+  "DisplayName": "{name} Display",
+  "InstallLocation": "{dir_str}",
+  "CatalogNamespace": "ns-{name}",
+  "CatalogItemId": "id-{name}",
+  "bIsApplication": true,
+  "bIsExecutable": true,
+  "bIsIncompleteInstall": false
+  {extra}
+}}"#,
+            name = name,
+            dir_str = dir.to_string_lossy().replace('\\', "/"),
+            extra = extra,
+        );
+        fs::write(dir.join(format!("{name}.item")), content).unwrap();
+    }
+
+    fn make_temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("epic_test_{}_{}", label, std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // ------------------------------------------------------------------ T005
+    #[test]
+    fn happy_path() {
+        let manifest_dir = make_temp_dir("happy");
+        write_manifest(&manifest_dir, "GameA", "");
+        write_manifest(&manifest_dir, "GameB", "");
+
+        let games = discover_games_from(&manifest_dir).expect("should succeed");
+        assert_eq!(games.len(), 2);
+
+        let mut names: Vec<String> = games.iter().map(|g| g.app_name.clone()).collect();
+        names.sort();
+        assert_eq!(names, ["GameA", "GameB"]);
+        // Every game should have display_name and install_location populated
+        assert!(games.iter().all(|g| !g.display_name.is_empty()));
+        assert!(games.iter().all(|g| !g.catalog_namespace.is_empty()));
+
+        fs::remove_dir_all(&manifest_dir).ok();
+    }
+
+    // ------------------------------------------------------------------ T006
+    #[test]
+    fn launcher_not_installed() {
+        let missing = std::env::temp_dir().join("epic_test_absent_dir_99999");
+        // Ensure it does not exist
+        let _ = fs::remove_dir_all(&missing);
+
+        let games = discover_games_from(&missing).expect("absent dir should return Ok");
+        assert!(games.is_empty());
+    }
+
+    // ------------------------------------------------------------------ T007
+    #[test]
+    fn malformed_manifest_skipped() {
+        let manifest_dir = make_temp_dir("malformed");
+        write_manifest(&manifest_dir, "GoodGame", "");
+        fs::write(manifest_dir.join("bad.item"), b"not valid json at all {{{{").unwrap();
+
+        let games = discover_games_from(&manifest_dir).expect("should succeed despite bad file");
+        assert_eq!(games.len(), 1);
+        assert_eq!(games[0].app_name, "GoodGame");
+
+        fs::remove_dir_all(&manifest_dir).ok();
+    }
+
+    // ------------------------------------------------------------------ T008
+    #[test]
+    fn incomplete_install_excluded() {
+        let manifest_dir = make_temp_dir("incomplete");
+        // bIsIncompleteInstall overrides the valid fields
+        let content = format!(
+            r#"{{
+  "AppName": "IncompleteGame",
+  "DisplayName": "Incomplete Game",
+  "InstallLocation": "{}",
+  "CatalogNamespace": "ns",
+  "CatalogItemId": "id",
+  "bIsApplication": true,
+  "bIsExecutable": true,
+  "bIsIncompleteInstall": true
+}}"#,
+            manifest_dir.to_string_lossy().replace('\\', "/")
+        );
+        fs::write(manifest_dir.join("incomplete.item"), content).unwrap();
+
+        let games = discover_games_from(&manifest_dir).expect("should succeed");
+        assert!(games.is_empty(), "incomplete installs must be excluded");
+
+        fs::remove_dir_all(&manifest_dir).ok();
+    }
+
+    // ------------------------------------------------------------------ T009
+    #[test]
+    fn non_application_excluded() {
+        let manifest_dir = make_temp_dir("non_app");
+        let content = format!(
+            r#"{{
+  "AppName": "NotAnApp",
+  "DisplayName": "Not An App",
+  "InstallLocation": "{}",
+  "CatalogNamespace": "ns",
+  "CatalogItemId": "id",
+  "bIsApplication": false,
+  "bIsExecutable": true,
+  "bIsIncompleteInstall": false
+}}"#,
+            manifest_dir.to_string_lossy().replace('\\', "/")
+        );
+        fs::write(manifest_dir.join("nonapp.item"), content).unwrap();
+
+        let games = discover_games_from(&manifest_dir).expect("should succeed");
+        assert!(games.is_empty(), "non-application entries must be excluded");
+
+        fs::remove_dir_all(&manifest_dir).ok();
+    }
+
+    // ------------------------------------------------------------------ launch_uri helper
+    #[test]
+    fn launch_uri_format() {
+        let dir = make_temp_dir("uri");
+        let game = EpicGame {
+            app_name: "Fortnite".to_string(),
+            display_name: "Fortnite".to_string(),
+            install_location: dir.clone(),
+            catalog_namespace: "fn".to_string(),
+            catalog_item_id: "4fe75bbc5a674f4f9b356b5c90567da5".to_string(),
+            cover_image: None,
+        };
+        assert_eq!(
+            game.launch_uri(),
+            "com.epicgames.launcher://apps/fn%3A4fe75bbc5a674f4f9b356b5c90567da5%3AFortnite?action=launch&silent=true"
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/components/GameCard.vue
+++ b/src/components/GameCard.vue
@@ -59,7 +59,7 @@ function onKeyDown(e: KeyboardEvent) {
       <span
         class="self-start text-[10px] font-medium px-1.5 py-0.5 rounded-sm text-zinc-400 bg-zinc-800"
       >
-        {{ game.platform === "steam" ? "Steam" : "Custom" }}
+        {{ game.platform === "steam" ? "Steam" : game.platform === "epic" ? "Epic" : "Custom" }}
       </span>
     </div>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -8,6 +8,7 @@ defineProps<{
   sortOption: SortOption;
   totalGames: number;
   steamCount: number;
+  epicCount: number;
   customCount: number;
   sidebarFocusedIndex: number; // -1 = sidebar not focused
 }>();
@@ -77,6 +78,7 @@ defineExpose({ focusSearch, focusSort, blurActive });
         v-for="(opt, idx) in ([
           { value: 'all',    label: 'All',    count: totalGames },
           { value: 'steam',  label: 'Steam',  count: steamCount },
+          { value: 'epic',   label: 'Epic',   count: epicCount },
           { value: 'custom', label: 'Custom', count: customCount },
         ] as const)"
         :key="opt.value"
@@ -99,7 +101,7 @@ defineExpose({ focusSearch, focusSort, blurActive });
       <p class="text-xs text-zinc-500 px-2 font-medium">Sort by</p>
       <div
         class="rounded-md"
-        :class="sidebarFocusedIndex === 4 ? 'ring-2 ring-zinc-500' : ''"
+        :class="sidebarFocusedIndex === 5 ? 'ring-2 ring-zinc-500' : ''"
       >
         <select
           ref="sortSelectRef"
@@ -124,7 +126,7 @@ defineExpose({ focusSearch, focusSort, blurActive });
       class="flex items-center justify-center gap-1.5 w-full px-3 py-2 rounded-md
              border border-zinc-700 text-zinc-300 text-sm font-medium
              hover:bg-zinc-800 hover:text-white transition-colors"
-      :class="sidebarFocusedIndex === 5 ? 'ring-2 ring-zinc-500' : ''"
+      :class="sidebarFocusedIndex === 6 ? 'ring-2 ring-zinc-500' : ''"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,6 +1,6 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 
-export type Platform = "steam" | "custom";
+export type Platform = "steam" | "epic" | "custom";
 
 export interface SteamGame {
   app_id: number;
@@ -17,9 +17,18 @@ export interface CustomGame {
   notes: string | null;
 }
 
+export interface EpicGame {
+  app_name: string;
+  display_name: string;
+  install_location: string;
+  catalog_namespace: string;
+  catalog_item_id: string;
+  cover_image: string | null;
+}
+
 /** Unified view model used throughout the UI */
 export interface Game {
-  /** Stable key: `steam-<appid>` or `custom-<uuid>` */
+  /** Stable key: `steam-<appid>`, `epic-<app_name>`, or `custom-<uuid>` */
   key: string;
   title: string;
   platform: Platform;
@@ -28,11 +37,13 @@ export interface Game {
   appId?: number;
   /** executable path — present for custom games */
   executable?: string;
+  /** pre-computed Epic launcher URI — present for Epic games */
+  epicLaunchUri?: string;
   tags: string[];
 }
 
 export type SortOption = "alpha" | "recentlyAdded";
-export type PlatformFilter = "all" | Platform;
+export type PlatformFilter = "all" | "steam" | "epic" | "custom";
 
 export function fromSteamGame(g: SteamGame): Game {
   return {
@@ -59,4 +70,15 @@ export function fromCustomGame(g: CustomGame): Game {
 function resolveCustomCover(path: string | null): string | null {
   if (!path) return null;
   return convertFileSrc(path);
+}
+
+export function fromEpicGame(g: EpicGame): Game {
+  return {
+    key: `epic-${g.app_name}`,
+    title: g.display_name,
+    platform: "epic",
+    coverImage: g.cover_image ? convertFileSrc(g.cover_image) : null,
+    epicLaunchUri: `com.epicgames.launcher://apps/${g.catalog_namespace}%3A${g.catalog_item_id}%3A${g.app_name}?action=launch&silent=true`,
+    tags: [],
+  };
 }


### PR DESCRIPTION
## Summary

- Closes https://github.com/joseiedo/game-library/issues/23
- Automatically discovers installed Epic Games titles from platform-appropriate manifest directories (`~/Library/Application Support/Epic/.../Manifests/` on macOS, `C:\ProgramData\Epic\...\Manifests\` on Windows)
- Displays Epic games in the unified library grid alongside Steam and custom games, each with an **"Epic"** platform badge
- Games are launchable via the `com.epicgames.launcher://` URI scheme using the existing `open_uri()` helper
- Cover art is loaded from the game's local installation directory (flat scan for PNG/JPEG); a placeholder is shown when none is found
- **Epic** platform filter added to the sidebar
- Graceful degradation: absent launcher → empty result, no error shown to user

## Changes

**Rust backend**
- `src-tauri/src/epic.rs` — new module: `EpicGame` struct, `EpicError`, `discover_games()`, `parse_manifest()` with `bIsApplication`/`bIsExecutable`/`bIsIncompleteInstall` filters, flat cover art scan
- `src-tauri/src/launcher.rs` — `LaunchTarget::EpicGame { launch_uri }` variant + dispatch in `launch()`
- `src-tauri/src/lib.rs` — `get_epic_games` Tauri command, `launch_game` extended with `epic_launch_uri: Option<String>`
- `src-tauri/Cargo.toml` — added `protocol-asset` feature (required by existing `assetProtocol` setting in `tauri.conf.json`)

**Vue 3 frontend**
- `src/types/game.ts` — `EpicGame` interface, `fromEpicGame()`, `epicLaunchUri?` on `Game`, `Platform`/`PlatformFilter` extended to include `"epic"`
- `src/App.vue` — `get_epic_games` invoked in parallel in `loadGames()`, `filter-epic` sidebar item + handler, `epicLaunchUri` passed to `launch_game`
- `src/components/GameCard.vue` — `"epic"` → `"Epic"` platform badge
- `src/components/Sidebar.vue` — Epic filter button, `epicCount` prop, corrected gamepad focus indices