### PR TITLE
feat(steam): add support for Proton games

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,6 +139,7 @@ async function confirmLaunch() {
     await invoke("launch_game", {
       key: game.key,
       appId: game.appId ?? null,
+      isShortcut: game.isShortcut ?? null,
       executable: game.executable ?? null,
       epicLaunchUri: game.epicLaunchUri ?? null,
     });

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -6,6 +6,7 @@ export interface SteamGame {
   app_id: number;
   name: string;
   install_dir: string;
+  is_shortcut: boolean;
 }
 
 export interface CustomGame {
@@ -35,6 +36,8 @@ export interface Game {
   coverImage: string | null;
   /** steam app id — present for Steam games */
   appId?: number;
+  /** non-steam games */
+  isShortcut?: boolean;
   /** executable path — present for custom games */
   executable?: string;
   /** pre-computed Epic launcher URI — present for Epic games */
@@ -52,6 +55,7 @@ export function fromSteamGame(g: SteamGame): Game {
     platform: "steam",
     coverImage: `https://cdn.cloudflare.steamstatic.com/steam/apps/${g.app_id}/library_600x900.jpg`,
     appId: g.app_id,
+    isShortcut: g.is_shortcut,
     tags: [],
   };
 }


### PR DESCRIPTION
Add ability to discover and launch non-Steam Proton games added to Steam via
"Add a Non-Steam Game" feature. These games use a different Steam URI
scheme (steam://rungameid/) with a CRC-derived ID instead of the normal
steam://run/ URI.

Changes include:
- Add SteamShortcut variant to LaunchTarget enum
- Add is_shortcut field to SteamGame struct and Game type
- Update app_id type from u32 to u64 to accommodate shortcut IDs
- Pass isShortcut flag through launch_game invoke call

Closes #3 